### PR TITLE
unmount the drive when container exits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial
 MAINTAINER Mitchell Hewes <me@mitcdh.com>
 
-ENV DRIVE_PATH="/drive"
+ENV DRIVE_PATH="/mnt/gdrive"
 
 RUN echo "deb http://ppa.launchpad.net/alessandro-strada/ppa/ubuntu xenial main" >> /etc/apt/sources.list \
  && echo "deb-src http://ppa.launchpad.net/alessandro-strada/ppa/ubuntu xenial main" >> /etc/apt/sources.list \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-DRIVE_PATH=/mnt/gdrive
+DRIVE_PATH=${DRIVE_PATH:-/mnt/gdrive}
 
 PUID=${PUID:-0}
 PGID=${PGID:-0}
@@ -52,7 +52,5 @@ fi
 
 # mount as the gdfuser user
 echo "mounting at ${DRIVE_PATH}"
-su gdfuser -l -c "google-drive-ocamlfuse \"${DRIVE_PATH}\"\
- -o uid=${PUID},gid=${PGID}${MOUNT_OPTS}"
-
-tail -f /dev/null & wait
+exec su gdfuser -l -c "google-drive-ocamlfuse \"${DRIVE_PATH}\"\
+ -f -o uid=${PUID},gid=${PGID}${MOUNT_OPTS}"


### PR DESCRIPTION
fix DRIVE_PATH so its not hard coded. use exec when running gdfuser and run google-drive-ocamlfuse in foreground (-f flag) so that when the container stops it will unmount properly and not leave the mount in a broken state. this allows you to restart the container without manually running some unmount flag to get it to start up again